### PR TITLE
Multi Content type release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Version: 3.6.0
-#### Date: Jul-25-2019
+#### Date: Jul-29-2019
 
 ##### New Features:
 - Query

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+### Version: 3.6.0
+#### Date: Jul-25-2019
+
+##### New Features:
+- Query
+   - added method 'includeReferenceContentTypeUid'
+   - added method 'locale'
+- Entry
+   - added method 'includeReferenceContentTypeUid'
+   - added method 'includeContentType'
+   - added method 'locale'
+   
+##### API deprecation:
+- Query
+   - deprecated method 'language'
+- Entry
+   - deprecated method 'language'
+   
+##### API removed:
+- Config
+   - removed property attribute 'ssl'
+   - removed method 'includeSchema'
+- Stack
+   - removed property attribute 'ssl'
+
 ### Version: 3.5.0
 #### Date: Apr-12-2019
 

--- a/Contentstack.podspec
+++ b/Contentstack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'Contentstack'
-s.version          = '3.5.0'
+s.version          = '3.6.0'
 s.summary          = 'Contentstack is a headless CMS with an API-first approach that puts content at the centre.'
 
 s.description      = <<-DESC
@@ -11,7 +11,7 @@ DESC
 s.homepage         = 'https://www.contentstack.com/'
 s.license          = { :type => 'Commercial',:text => 'See https://www.contentstack.com/'}
 s.author           = { 'Contentstack' => 'support@contentstack.io' }
-s.source           = { :git => 'https://github.com/contentstack/contentstack-ios.git', :tag => '3.5.0' }
+s.source           = { :git => 'https://github.com/contentstack/contentstack-ios.git', :tag => '3.6.0' }
 s.social_media_url = 'https://twitter.com/Contentstack'
 
 s.ios.deployment_target = '8.0'

--- a/Contentstack.xcodeproj/project.pbxproj
+++ b/Contentstack.xcodeproj/project.pbxproj
@@ -46,7 +46,6 @@
 		0F9C0FC6221ADAC90091205A /* SyncStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9C0FAD221ADAC90091205A /* SyncStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F9C0FC7221ADAC90091205A /* Entry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9C0FAE221ADAC90091205A /* Entry.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F9C0FC8221ADAC90091205A /* NamespacedDependencies.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9C0FB0221ADAC90091205A /* NamespacedDependencies.h */; };
-		0FFF87B2226F251B005243EA /* FallbackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FFF87B0226F1A59005243EA /* FallbackTest.m */; };
 		230B38E41C16EB4400444A14 /* MMDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 565E11AA1BD76654005AD47F /* MMDocument.m */; };
 		230B38E51C16EB4400444A14 /* MMElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 565E11AD1BD76654005AD47F /* MMElement.m */; };
 		230B38E61C16EB4400444A14 /* MMGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 565E11AF1BD76654005AD47F /* MMGenerator.m */; };
@@ -759,7 +758,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0FFF87B2226F251B005243EA /* FallbackTest.m in Sources */,
 				FA36C00820ECABDF000FF701 /* SyncTest.m in Sources */,
 				23A53F581E277CD3001DBE35 /* ContentstackTest.m in Sources */,
 			);

--- a/Contentstack/Config.h
+++ b/Contentstack/Config.h
@@ -31,20 +31,6 @@
 @property (nonatomic, copy) NSString *host;
 
 /**
- SSL state of Contentstack api server.
- 
-     //Obj-C
-    Config *config = [[Config alloc] init];
-     config.isSSL = YES;
-     
-     //Swift
-     var config:Config = Config()
-     config.isSSL = true
- 
- */
-@property (nonatomic, assign) BOOL isSSL DEPRECATED_ATTRIBUTE;
-
-/**
  API version of Contentstack api server.
  
      //Obj-C

--- a/Contentstack/Config.m
+++ b/Contentstack/Config.m
@@ -14,7 +14,6 @@
     self = [super init];
     if (self) {
         _host = kCSIO_DefaultHost;
-        _isSSL = kCSIO_DefaultHostSSL;
         _version = kCSIO_ApiVersion;        
     }
     return self;

--- a/Contentstack/Entry.h
+++ b/Contentstack/Entry.h
@@ -52,7 +52,11 @@ BUILT_ASSUME_NONNULL_BEGIN
 /**
  *  Readonly property to check Language of entry
  */
-@property (nonatomic, assign) Language language;
+@property (nonatomic, assign) Language language __attribute((deprecated("Use the locale instead.")));
+/**
+ *  Readonly property to check Language of entry
+ */
+@property (nonatomic, assign) NSString *locale;
 
 /**
  *  Readonly property to check createAt of entry
@@ -322,6 +326,31 @@ BUILT_ASSUME_NONNULL_BEGIN
  * @name Only and Except
  *  ---------------------------------------------------------------------------------------
  */
+
+
+/**
+ This method also includes the contenttype for the entries returned in the response.
+ 
+       //Obj-C
+       [entryObj includeContentType];
+ 
+       //Swift
+       entryObj.includeContentType()
+ 
+ */
+- (void)includeContentType;
+
+/**
+ This method also includes the contenttype uid for the reference entries returned in the response.
+ 
+      //Obj-C
+      [entryObj includeReferenceContentTypeUid];
+ 
+      //Swift
+      entryObj.includeReferenceContentTypeUid(])
+ 
+ */
+- (void)includeReferenceContentTypeUid;
 
 /**
 Specifies an array of 'only' keys in BASE object that would be included in the response.

--- a/Contentstack/Entry.h
+++ b/Contentstack/Entry.h
@@ -341,7 +341,7 @@ BUILT_ASSUME_NONNULL_BEGIN
 - (void)includeContentType;
 
 /**
- This method also includes the contenttype uid for the reference entries returned in the response.
+ This method also includes the content type UIDs of the referenced entries returned in the response.
  
       //Obj-C
       [entryObj includeReferenceContentTypeUid];

--- a/Contentstack/Entry.m
+++ b/Contentstack/Entry.m
@@ -52,7 +52,12 @@
 
 -(void)setLanguage:(Language)language {
     _language = language;
-    [self.postParamDictionary setValue:[self localeCode:language] forKey:kCSIO_Locale];
+    [self setLocale:[self localeCode:language]];
+}
+
+-(void)setLocale:(NSString *)locale {
+    _locale = locale;
+    [self.postParamDictionary setValue:locale forKey:kCSIO_Locale];
 }
 
 - (instancetype)initWithContentType:(ContentType*)contentType {
@@ -96,7 +101,7 @@
     }
     
     if (self.objectProperties[kCSIO_Locale]) {
-        self.language = [self indexOfLocaleCodeString:self.objectProperties[kCSIO_Locale]];
+        self.locale = self.objectProperties[kCSIO_Locale];
     }
     
     if (self.objectProperties[kCSIO_Tags]) {
@@ -224,6 +229,14 @@
 }
 
 //MARK: - Reference fields -
+
+- (void)includeContentType {
+    [self.postParamDictionary setObject:@"true" forKey:kCSIO_IncludeContentType];
+}
+
+- (void)includeReferenceContentTypeUid {
+    [self.postParamDictionary setObject:@"true" forKey:kCSIO_IncludeRefContentTypeUID];
+}
 
 - (void)includeRefFieldWithKey:(NSArray *)key;{
     if ([self.postParamDictionary objectForKey:kCSIO_Include] != nil) {

--- a/Contentstack/Query.h
+++ b/Contentstack/Query.h
@@ -269,7 +269,7 @@ Provides only the number of entries with values matching the specified values fo
 
 
 /**
- This method also includes the contenttype uid for the reference entries returned in the response.
+ This method also includes the content type UIDs of the referenced entries returned in the response.
  
  //Obj-C
  [blogQuery includeReferenceContentTypeUid];

--- a/Contentstack/Query.h
+++ b/Contentstack/Query.h
@@ -96,7 +96,20 @@ This method provides all the entries for the specified language in the response.
 
 @param language Language enum for all language available.
  */
-- (void)language:(Language)language;
+- (void)language:(Language)language __attribute((deprecated("Use the locale: instead.")));
+
+/**
+ This method provides all the entries for the specified language in the response.
+ 
+ //Obj-C
+ [blogQuery locale:@"en-us"];
+ 
+ //Swift
+ blogQuery.locale("en-us")
+ 
+ @param locale Language enum for all language available.
+ */
+- (void)locale:(NSString *)locale;
 
 //MARK: - Search -
 /**---------------------------------------------------------------------------------------
@@ -243,18 +256,6 @@ Provides only the number of entries with values matching the specified values fo
 - (void)objectsCount;
 
 /**
-This method also includes the schema of the contenttype for the entries returned in the response.
- 
-     //Obj-C
-     [blogQuery includeSchema];
-     
-     //Swift
-     blogQuery.includeSchema()
- 
- */
-- (void)includeSchema __attribute((deprecated("Use the includeContentType instead.")));;
-
-/**
  This method also includes the contenttype for the entries returned in the response.
  
      //Obj-C
@@ -265,6 +266,19 @@ This method also includes the schema of the contenttype for the entries returned
  
  */
 - (void)includeContentType;
+
+
+/**
+ This method also includes the contenttype uid for the reference entries returned in the response.
+ 
+ //Obj-C
+ [blogQuery includeReferenceContentTypeUid];
+ 
+ //Swift
+ includeReferenceContentTypeUid()
+ 
+ */
+- (void)includeReferenceContentTypeUid;
 
 /**
 This method also includes owner information for all the entries returned in the response.

--- a/Contentstack/Query.m
+++ b/Contentstack/Query.m
@@ -63,6 +63,11 @@ static NSString *kNOT_HAVING = @"$nin_query";
     [self.queryDictionary setObject:[self localeCode:(NSUInteger)language] forKey:kCSIO_Locale];
 }
 
+
+- (void)locale:(NSString *)locale {
+    [self.queryDictionary setObject:locale forKey:kCSIO_Locale];
+}
+
 //MARK: - Search -
 - (void)search:(NSString*)searchString {
     // [self prepareQuerywithOperation:nil subKey:kCSIO_Typeahead forKey:kCSIO_Queryable withObject:searchString];
@@ -112,12 +117,6 @@ static NSString *kNOT_HAVING = @"$nin_query";
     [self.queryDictionary setObject:@"true" forKey:kCSIO_Count];
 }
 
-- (void)includeSchema {
-    if ([self.queryDictionary valueForKey:kCSIO_IncludeContentType] == nil){
-        [self.queryDictionary setObject:@"true" forKey:kCSIO_IncludeSchema];
-    }
-}
-
 - (void)includeContentType {
     if ([self.queryDictionary valueForKey:kCSIO_IncludeSchema] != nil){
         [self.queryDictionary  removeObjectForKey:kCSIO_IncludeSchema];
@@ -125,6 +124,9 @@ static NSString *kNOT_HAVING = @"$nin_query";
     [self.queryDictionary setObject:@"true" forKey:kCSIO_IncludeContentType];
 }
 
+- (void)includeReferenceContentTypeUid {
+    [self.queryDictionary setObject:@"true" forKey:kCSIO_IncludeRefContentTypeUID];
+}
 
 - (void)includeOwner {
     [self.queryDictionary setObject:@"true" forKey:kCSIO_IncludeUser];
@@ -451,7 +453,7 @@ static NSString *kNOT_HAVING = @"$nin_query";
     NSMutableDictionary *headers = [NSMutableDictionary dictionaryWithDictionary:self.contentType.headers];
 
     [headers addEntriesFromDictionary:self.localHeaders];
-    
+    paramDictionary[@"include_reference_content_type_uid"] = @"true";
     NSString *path = [CSIOAPIURLs fetchContentTypeEntriesQueryURLWithUID:[self.contentType name] withVersion:self.contentType.stack.version];
     
     NSURLSessionDataTask *op = [self.contentType.stack.network requestForStack:self.contentType.stack withURLPath:path requestType:CSIOCoreNetworkingRequestTypeGET params:paramDictionary additionalHeaders:headers cachePolicy:self.cachePolicy completion:^(ResponseType responseType, id responseJSON, NSError *error) {

--- a/Contentstack/Stack.m
+++ b/Contentstack/Stack.m
@@ -31,7 +31,6 @@
         _config = sConfig;
 
         _hostURL = [sConfig.host copy];
-        _ssl = sConfig.isSSL;
         _version = [sConfig.version copy];
         _environment = [environment copy];
 

--- a/ContentstackInternal/CSIOConstants.h
+++ b/ContentstackInternal/CSIOConstants.h
@@ -55,6 +55,7 @@ FOUNDATION_EXPORT NSString *const kCSIO_Regex;
 FOUNDATION_EXPORT NSString *const kCSIO_Options;
 FOUNDATION_EXPORT NSString *const kCSIO_IncludeSchema;
 FOUNDATION_EXPORT NSString *const kCSIO_IncludeContentType;
+FOUNDATION_EXPORT NSString *const kCSIO_IncludeRefContentTypeUID;
 FOUNDATION_EXPORT NSString *const kCSIO_IncludeCount;
 FOUNDATION_EXPORT NSString *const kCSIO_IncludeUnpublished;
 FOUNDATION_EXPORT NSString *const kCSIO_BeforeUID;

--- a/ContentstackInternal/CSIOConstants.m
+++ b/ContentstackInternal/CSIOConstants.m
@@ -59,6 +59,7 @@ NSString *const kCSIO_Owner = @"_owner";
 //include
 NSString *const kCSIO_IncludeSchema = @"include_schema";
 NSString *const kCSIO_IncludeContentType = @"include_content_type";
+NSString *const kCSIO_IncludeRefContentTypeUID = @"include_reference_content_type_uid";
 NSString *const kCSIO_IncludeCount = @"include_count";
 NSString *const kCSIO_IncludeUnpublished = @"include_unpublished";
 //

--- a/ContentstackInternal/CSIOCoreHTTPNetworking.m
+++ b/ContentstackInternal/CSIOCoreHTTPNetworking.m
@@ -171,8 +171,8 @@ NSArray * CSIOQueryStringPairsFromKeyAndValue(NSString *key, id value) {
 
 }
     
-- (NSString *)protocolStringForSSL:(BOOL)isSSL {
-    return isSSL ? @"https" : @"http";
+- (NSString *)protocolStringForSSL {
+    return @"https";
 }
 
 //MARK: - Cache
@@ -244,7 +244,7 @@ NSArray * CSIOQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     
     NSString* urlString = urlPath;
     if (urlPath && !([urlPath hasPrefix:@"http"] || [urlPath hasPrefix:@"https"])) {
-        urlString = [NSString stringWithFormat:@"%@://%@%@", [self protocolStringForSSL:stack.ssl], stack.hostURL, urlPath];
+        urlString = [NSString stringWithFormat:@"%@://%@%@", [self protocolStringForSSL], stack.hostURL, urlPath];
     }
     NSString* requestMethod = [self reqestMethodStringForRequestType:requestType];
     
@@ -298,7 +298,7 @@ NSArray * CSIOQueryStringPairsFromKeyAndValue(NSString *key, id value) {
     
     NSString* urlString = urlPath;
     if (urlPath && !([urlPath hasPrefix:@"http"] || [urlPath hasPrefix:@"https"])) {
-        urlString = [NSString stringWithFormat:@"%@://%@%@", [self protocolStringForSSL:stack.ssl], stack.hostURL, urlPath];
+        urlString = [NSString stringWithFormat:@"%@://%@%@", [self protocolStringForSSL], stack.hostURL, urlPath];
     }
     // Cache handler
     ResponseType resType = NETWORK;

--- a/ContentstackInternal/CSIOInternalHeaders.h
+++ b/ContentstackInternal/CSIOInternalHeaders.h
@@ -28,7 +28,6 @@
 @interface Stack ()
 @property (nonatomic, copy) NSString *hostURL;
 @property (nonatomic, copy) NSString *version;
-@property (nonatomic, assign) BOOL ssl DEPRECATED_ATTRIBUTE; 
 @property (nonatomic, strong) NSMutableDictionary *stackHeaders;
 @property (nonatomic, strong) NSObject<CSIOCoreNetworkingProtocol> *network;
 @property (nonatomic, strong) ISO8601DateFormatter *commonDateFormatter;

--- a/ContentstackTest/ContentstackTest.m
+++ b/ContentstackTest/ContentstackTest.m
@@ -51,25 +51,25 @@ static NSInteger kRequestTimeOutInSeconds = 400;
 @implementation ContentstackTest
 
 
-//Run TEST Case on terminal using set -o pipefail && env "NSUnbufferedIO=YES" xcodebuild "-workspace" "ContentStackSDK.xcworkspace" "-scheme" "Contentstack" "build" "test" "-destination" "id=841529D1-AEC3-4FF7-8AA4-079845D4FD4C" | xcpretty "--color" "--report" "html" "--output" "/Users/uttamukkoji/Documents/GitHub/contentstack-ios/ContentstackTest/TestResult/xcode-test-results-Contentstack.html"
+//Run TEST Case on terminal using set -o pipefail && env "NSUnbufferedIO=YES" xcodebuild "-workspace" "ContentStack.xcworkspace" "-scheme" "Contentstack" "build" "test" "-destination" "id=841529D1-AEC3-4FF7-8AA4-079845D4FD4C" | xcpretty "--color" "--report" "html" "--output" "/Users/uttamukkoji/Documents/GitHub/contentstack-ios/ContentstackTest/TestResult/xcode-test-results-Contentstack.html"
 
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     config = [[Config alloc] init];
-    config.host = @"api.blz-contentstack.com";
-    csStack = [Contentstack stackWithAPIKey:@"bltdd35c1a9e76490cc" accessToken:@"cs8bfa982bac402ba16e91d2b6" environmentName:@"env1" config:config];
-    _assetUid = @"blt304889595d537009";
-    _productUid = @"blt508e396ec8fff3ac";
-    _multiplefieldtUid = @"bltf17eccd3d47b4833";
-    _userUid = @"blt63f56ac7f48fc478";
+//    config.host = @"api.blz-contentstack.com";
+//    csStack = [Contentstack stackWithAPIKey:@"bltdd35c1a9e76490cc" accessToken:@"cs8bfa982bac402ba16e91d2b6" environmentName:@"env1" config:config];
+//    _assetUid = @"blt304889595d537009";
+//    _productUid = @"blt508e396ec8fff3ac";
+//    _multiplefieldtUid = @"bltf17eccd3d47b4833";
+//    _userUid = @"blt63f56ac7f48fc478";
 
-//    config.host = @"cdn.contentstack.io";//@"cdn.contentstack.io";//@"stagcontentstack.global.ssl.fastly.net";//@"dev-cdn.contentstack.io";
-//    csStack = [Contentstack stackWithAPIKey:@"blt12c8ad610ff4ddc2" accessToken:@"blt43359585f471685188b2e1ba" environmentName:@"env1" config:config];
-//    _productUid = @"blt04fe803db48a65a3";
-//    _multiplefieldtUid = @"blt1b1cb4f26c4b682e";
-//    _assetUid = @"blt5312f71416d6e2c8";
-//    _userUid = @"blt3b0aaebf6f1c3762";
+    config.host = @"stag-cdn.contentstack.io";//@"cdn.contentstack.io";//@"stagcontentstack.global.ssl.fastly.net";//@"dev-cdn.contentstack.io";
+    csStack = [Contentstack stackWithAPIKey:@"blt12c8ad610ff4ddc2" accessToken:@"blt43359585f471685188b2e1ba" environmentName:@"env1" config:config];
+    _productUid = @"blt04fe803db48a65a3";
+    _multiplefieldtUid = @"blt1b1cb4f26c4b682e";
+    _assetUid = @"blt5312f71416d6e2c8";
+    _userUid = @"blt3b0aaebf6f1c3762";
 }
 
 - (void)waitForRequest {
@@ -197,7 +197,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
 
 -(void)checkLanguageStatus:(Entry *)obj {
     
-    if (obj.language == ENGLISH_UNITED_STATES) {
+    if ([obj.locale isEqual: @"en-us"]) {
         XCTAssert(YES, @"Pass");
     } else {
         XCTFail(@"check Language");
@@ -209,62 +209,6 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     XCTAssertTrue(resultArray.count > 0, @"Product count should not be 0");
 }
 
-//#pragma mark -
-//#pragma mark Test Case - Last Activity
-//
-//- (void)testFetchLastActivity {
-//    XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Last Activity"];
-//
-//    [csStack fetchLastActivity:^(ResponseType responseType, NSDictionary * _Nonnull lastActivity, NSError * _Nonnull error) {
-//
-//        if (error) {
-//            XCTFail(@"~ ERR: %@", error.userInfo);
-//        }else {
-//            NSLog(@"lastActivityDictionary %@",lastActivity);
-//            XCTAssertNotNil(lastActivity, @"response should not be nil");
-//
-//            XCTAssertTrue([lastActivity isKindOfClass:[NSDictionary class]], @"Response should be NSDictionary");
-//            XCTAssertTrue([lastActivity[@"product"] isKindOfClass:[NSArray class]], @"Value of key should be NSArray");
-//            NSArray *objArray = (NSArray *)lastActivity[@"product"];
-//            XCTAssertTrue([objArray[0] isKindOfClass:[NSDictionary class]], @"Object should be NSDictionary");
-//            NSDictionary *obj = objArray[0];
-//            NSArray *checkArry = @[@"locale",@"time"];
-//            XCTAssertTrue([obj.allKeys isEqualToArray:checkArry],@"Data not Matched");
-//
-//        }
-//        [expectation fulfill];
-//
-//    }];
-//
-//    [self waitForRequest];
-//}
-//
-//- (void)testFetchSchema {
-//    XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Schema"];
-//
-//   [csStack fetchSchema:^(ResponseType responseType, NSArray * _Nullable schema, NSError * _Nullable error) {
-//
-//       if (error) {
-//           XCTFail(@"~ ERR: %@", error.userInfo);
-//       } else {
-//
-//           [schema enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-//               XCTAssertTrue([obj isKindOfClass:[NSDictionary class]], @"array value should be NSDictionary");
-//               XCTAssertTrue([obj[@"schema"] isKindOfClass:[NSArray class]], @"Value of key should be NSArray");
-//               NSArray *objArray = (NSArray *)obj[@"schema"];
-//               XCTAssertTrue([objArray[0] isKindOfClass:[NSDictionary class]], @"Object should be NSDictionary");
-//               NSDictionary *arrObj = objArray[0];
-//               NSArray *checkArry = @[@"data_type",@"uid",@"field_metadata"];
-//              [checkArry enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL * _Nonnull stop) {
-//                  XCTAssertTrue([arrObj.allKeys containsObject:key],@"Data not Matched");
-//              }];
-//
-//           }];
-//       }
-//       [expectation fulfill];
-//   }];
-//    [self waitForRequest];
-//}
 
 #pragma mark -
 #pragma mark Test Case - Markdown
@@ -357,7 +301,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
         }else {
             [self checkLanguageStatus:entry];
             
-            NSLog(@"result %lu", (unsigned long)entry.language);
+            NSLog(@"result %@", entry.locale);
             
             NSArray *markdownArray = [entry HTMLArrayForMarkdownKey:@"markdown_multiple"];
             [markdownArray enumerateObjectsUsingBlock:^(NSString *markdownString, NSUInteger idx, BOOL * _Nonnull stop) {
@@ -443,7 +387,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
             if ([assetObj.url length] > 0) {
                 
                 NSString *strImgURLAsString = assetObj.url;
-                [strImgURLAsString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                [strImgURLAsString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
                 NSURL *imgURL = [NSURL URLWithString:strImgURLAsString];
                 [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:imgURL] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
                     if (!connectionError) {
@@ -551,6 +495,37 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     [self waitForRequest];
 }
 
+- (void)testFetchIncludeRefContentTypeUid {
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Single Entry with Reference  Content type"];
+    
+    ContentType* csForm = [csStack contentTypeWithName:@"product"];
+    
+    Entry *entry = [csForm entryWithUID:_productUid];
+    [entry includeReferenceContentTypeUid];
+    
+    [entry fetch:^(ResponseType type, NSError *error) {
+        if (error) {
+            XCTFail(@"~ ERR: %@, Message = %@", error.userInfo, error.description);
+        }else {
+            if ([[entry valueForKey:@"category"] isKindOfClass:[NSArray class]]) {
+                NSArray *catArray = [entry valueForKey:@"category"];
+                for (id category in catArray) {
+                    XCTAssertTrue([category isKindOfClass:[NSDictionary class]], "Category should be of type NSDictionary.");
+                    if ([category isKindOfClass:[NSDictionary class]]) {
+                        NSDictionary *catagoryDict = category;
+                        XCTAssertTrue([catagoryDict.allKeys containsObject:@"_content_type_uid"], "Category should have '_content_type_uid' key.");
+                    }
+                }
+            }
+            
+        }
+        [expectation fulfill];
+
+    }];
+    [self waitForRequest];
+
+}
 - (void)testFetchIncludeOnlyFields {
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Single Entry"];
@@ -1669,31 +1644,6 @@ static NSInteger kRequestTimeOutInSeconds = 400;
 //    [self waitForRequest];
 //}
 
-- (void)testFetchWithSchema {
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Entries with Schema"];
-    
-    ContentType* csForm = [csStack contentTypeWithName:@"product"];
-    
-    Query* csQuery = [csForm query];
-    [csQuery includeSchema];
-    [csQuery find:^(ResponseType type, QueryResult *result, NSError *error) {
-        
-        if (error) {
-            XCTFail(@"~ ERR: %@", error.userInfo);
-        } else {
-            [[result schema] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-                XCTAssertTrue([result schema], "Schema should be present");
-            }];
-        }
-        
-        [expectation fulfill];
-        
-    }];
-    
-    [self waitForRequest];
-}
-
 - (void)testFetchWithContentType {
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Entries with Content type"];
@@ -1730,7 +1680,6 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     ContentType* csForm = [csStack contentTypeWithName:@"product"];
     
     Query* csQuery = [csForm query];
-    [csQuery includeSchema];
     [csQuery includeContentType];
     [csQuery find:^(ResponseType type, QueryResult *result, NSError *error) {
         
@@ -1755,6 +1704,36 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     [self waitForRequest];
 }
 
+- (void)testFetchWithIncludeReferenceContentTypeUID {
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Entries with Schema"];
+    
+    ContentType* csForm = [csStack contentTypeWithName:@"product"];
+    Query* csQuery = [csForm query];
+    [csQuery includeReferenceContentTypeUid];
+    [csQuery find:^(ResponseType type, QueryResult *result, NSError *error) {
+        if (error) {
+            XCTFail(@"~ ERR: %@", error.userInfo);
+        } else {
+            [[result getResult] enumerateObjectsUsingBlock:^(Entry *obj, NSUInteger idx, BOOL * _Nonnull stop) {
+                if ([[obj valueForKey:@"category"] isKindOfClass:[NSArray class]]) {
+                    NSArray *catArray = [obj valueForKey:@"category"];
+                    for (id category in catArray) {
+                        XCTAssertTrue([category isKindOfClass:[NSDictionary class]], "Category should be of type NSDictionary.");
+                        if ([category isKindOfClass:[NSDictionary class]]) {
+                            NSDictionary *catagoryDict = category;
+                            XCTAssertTrue([catagoryDict.allKeys containsObject:@"_content_type_uid"], "Category should have '_content_type_uid' key.");
+                        }
+                    }
+                }
+            }];
+        }
+        [expectation fulfill];
+    }];
+    
+    [self waitForRequest];
+}
+
 
 - (void)testFetchWithContentTypeAndSchema {
     
@@ -1764,7 +1743,6 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     
     Query* csQuery = [csForm query];
     [csQuery includeContentType];
-    [csQuery includeSchema];
     [csQuery find:^(ResponseType type, QueryResult *result, NSError *error) {
         
         if (error) {
@@ -1845,7 +1823,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     ContentType* csForm = [csStack contentTypeWithName:@"product"];
     
     Query* csQuery = [csForm query];
-    [csQuery language:ENGLISH_UNITED_STATES];
+    [csQuery locale:@"en-us"];
     [csQuery whereKey:@"uid" equalTo:_productUid];
     
     
@@ -1860,7 +1838,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
                 
                 [self checkLanguageStatus:obj];
                 
-                if(obj.language != ENGLISH_UNITED_STATES){
+                if(obj.locale == @"en-us"){
                     XCTFail(@"Object does not have ENGLISH_UNITED_STATES language.");
                 }
             }];
@@ -1963,9 +1941,8 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     ContentType* csForm = [csStack contentTypeWithName:@"product"];
     
     Query* csQuery = [csForm query];
-    [csQuery includeSchema];
     
-    NSString *titleString = @"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took";
+    NSString *titleString = @"Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum. ********************** Lorem Ipsum is simply dummy text of the printing and typesetting industry.";
     
     [csQuery whereKey:@"title" notEqualTo:titleString];
     

--- a/ContentstackTest/FallbackTest.m
+++ b/ContentstackTest/FallbackTest.m
@@ -53,6 +53,7 @@ static NSInteger kRequestTimeOutInSeconds = 400;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch Set Header"];
     Entry *entry = [[csStack contentTypeWithName:@"product"] entryWithUID:@"bltf6156698a6494737"];
     entry.language = MARATHI_INDIA;
+    [entry includeRefFieldWithKey:@[@"category"]];
 //    [entry addParamKey:@"locale" andValue:@"mr-in"];
     
     [entry fetch:^(ResponseType type, NSError * _Nullable error) {

--- a/ContentstackTest/SyncTest.m
+++ b/ContentstackTest/SyncTest.m
@@ -25,24 +25,24 @@ static NSInteger kRequestTimeOutInSeconds = 400;
 - (void)setUp {
     [super setUp];
     // Blizaard Config
-    Config *_config = [[Config alloc] init];
-    _config.host = @"cdn.blz-contentstack.com";
-    syncToken = @"blt8d1e3075c44837c3057913";//Prod
-    csStack = [Contentstack stackWithAPIKey:@"blt59ea7afd1eb58d12" accessToken:@"cs20ec62a477546ef68ded62a8" environmentName:@"web" config:_config];
+//    Config *_config = [[Config alloc] init];
+//    _config.host = @"cdn.blz-contentstack.com";
+//    syncToken = @"blt8d1e3075c44837c3057913";//Prod
+//    csStack = [Contentstack stackWithAPIKey:@"blt59ea7afd1eb58d12" accessToken:@"cs20ec62a477546ef68ded62a8" environmentName:@"web" config:_config];
     
     
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    // Prod
+//     Prod
 //    Config *_config = [[Config alloc] init];
 //    _config.host = @"cdn.contentstack.io";
 //    syncToken = @"blt37f6aa8e41cbb327c6c6d3";//Prod
 //    csStack = [Contentstack stackWithAPIKey:@"blt477ba55f9a67bcdf" accessToken:@"cs7731f03a2feef7713546fde5" environmentName:@"web" config:_config];
 //
     //Stag
-//    Config *_config = [[Config alloc] init];
-//    _config.host = @"stag-cdn.contentstack.io";
-//    syncToken = @"blt37f6aa8e41cbb327c6c6d3";//stage
-//    csStack = [Contentstack stackWithAPIKey:@"blt477ba55f9a67bcdf" accessToken:@"cs7731f03a2feef7713546fde5" environmentName:@"web" config:_config];
+    Config *_config = [[Config alloc] init];
+    _config.host = @"stag-cdn.contentstack.io";
+    syncToken = @"blt37f6aa8e41cbb327c6c6d3";//stage
+    csStack = [Contentstack stackWithAPIKey:@"blt477ba55f9a67bcdf" accessToken:@"cs7731f03a2feef7713546fde5" environmentName:@"web" config:_config];
 
     //Dev
 //    Config *_config = [[Config alloc] init];


### PR DESCRIPTION
### Version: 3.6.0

##### New Features:
- Query
   - added method 'includeReferenceContentTypeUid'
   - added method 'locale'
- Entry
   - added method 'includeReferenceContentTypeUid'
   - added method 'includeContentType'
   - added method 'locale'
   
##### API deprecation:
- Query
   - deprecated method 'language'
- Entry
   - deprecated method 'language'
   
##### API removed:
- Config
   - removed property attribute 'ssl'
   - removed method 'includeSchema'
- Stack
   - removed property attribute 'ssl'