### PR TITLE
Update documentation to announce deprecation of CocoaPods distribution and Objective-C SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Documentation (announcement phase)
+#### Date: Mar-31-2026
+
+##### Documentation:
+ - README and Docs/overview: Customer-facing deprecation announcement (new development → Swift CDA + SPM).
+ - Added `DEPRECATION.md`: customer-facing deprecation notice (Swift SDK + SPM, existing CocoaPods users, support expectations, industry context).
+
 ### Version: 3.16.0
 #### Date: Sep-22-2025
 

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,0 +1,34 @@
+# Deprecation notice: Contentstack iOS SDK (CocoaPods)
+
+This page is for **developers using the Contentstack iOS SDK** distributed through **CocoaPods** and the **Objective-C** Content Delivery API (CDA) client in this repository.
+
+## What this means for you
+
+**We are deprecating this SDK as the recommended path for new iOS work.** If you are **starting a new project**, use our **[Contentstack Swift SDK](https://github.com/contentstack/contentstack-swift)** instead, and add it with **Swift Package Manager** (see links below).
+
+**If you already ship an app** that uses `pod 'Contentstack'`, you can **keep using it**. Your integration continues to work. Plan a move to the Swift SDK when it fits your release schedule—you do not have to change immediately.
+
+## What to use for new projects
+
+| | Link |
+|---|------|
+| **Swift SDK (recommended)** | [github.com/contentstack/contentstack-swift](https://github.com/contentstack/contentstack-swift) |
+| **Add the package (SPM)** | [Swift Package Index – Contentstack Swift SDK](https://swiftpackageindex.com/contentstack/contentstack-swift) |
+| **API documentation** | [Contentstack Swift SDK (CDA) reference](https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/swift/reference) |
+
+The Swift SDK is actively maintained and is where new features and improvements will appear.
+
+## Why we are making this change
+
+The wider **CocoaPods** ecosystem is [moving to a read-only model for publishing new pod versions](https://blog.cocoapods.org/CocoaPods-Specs-Repo/). This Objective-C SDK has been delivered mainly through CocoaPods; aligning **new** development on our **Swift** SDK and **SPM** matches where the platform and our product investment are headed.
+
+## Support for this SDK going forward
+
+This repository will stay in **maintenance**: we may address critical or security issues where we can, but **we do not plan new features** here. Feature work goes into the Swift SDK.
+
+## Dates worth knowing
+
+- The CocoaPods project has published a timeline for when **new pod versions** can no longer be submitted to their central registry, with a milestone around **December 2, 2026**. See their **[official announcement](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)** for full detail.
+- That industry change is separate from your day-to-day use of an **already published** `Contentstack` pod version today—existing installs are not “turned off” by Contentstack because of this page.
+
+If you need help choosing a migration path or timing, contact **[Contentstack support](https://www.contentstack.com/)** or your account team.

--- a/Docs/overview.md
+++ b/Docs/overview.md
@@ -1,9 +1,17 @@
-#Overview
+# Overview
+
+## Important: CocoaPods and this SDK
+
+**We are deprecating** the **Contentstack** CocoaPods distribution and this **Objective-C** CDA SDK as the path for **new** development. **New projects should use the [Contentstack Swift CDA SDK](https://github.com/contentstack/contentstack-swift)** with **[Swift Package Manager](https://swiftpackageindex.com/contentstack/contentstack-swift)** and the [Swift CDA reference](https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/swift/reference).
+
+**Already using this SDK?** You can keep your current CocoaPods setup and migrate when ready. More detail: **[DEPRECATION.md](../DEPRECATION.md)**.
+
+---
 
 [Contentstack](https://www.contentstack.com/) is a content management system that facilitates the process of publication by separating the content from site-related programming and design.
 
 #### Installation
-#####**[CocoaPods (Recommended)](https://cocoapods.org)**
+##### **[CocoaPods](https://cocoapods.org)**
 
 Add the following line to your Podfile:  
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 [![Contentstack](https://www.contentstack.com/docs/static/images/contentstack.png)](https://www.contentstack.com/)
 
+## Important: CocoaPods and this SDK
+
+**We are deprecating** the **Contentstack** CocoaPods distribution and this **Objective-C** Content Delivery API (CDA) SDK as the supported path for **new** development. **New iOS projects should use the [Contentstack Swift CDA SDK](https://github.com/contentstack/contentstack-swift)** with **[Swift Package Manager](https://swiftpackageindex.com/contentstack/contentstack-swift)** and the [Swift CDA reference](https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/swift/reference).
+
+**Already using this SDK?** You can keep shipping with your current CocoaPods setup and migrate to the Swift SDK when it makes sense for your app. More detail: **[DEPRECATION.md](DEPRECATION.md)**.
+
 ## iOS SDK for Contentstack
 
 Contentstack is a headless CMS with an API-first approach. It is a CMS that developers can use to build powerful cross-platform applications in their favorite languages. Build your application frontend, and Contentstack will take care of the rest. [Read More](https://www.contentstack.com/).


### PR DESCRIPTION
 Added details in README, overview, and new DEPRECATION.md for migration to Swift SDK with SPM.