### PR TITLE
Fix Snyk issue and update version to 3.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
  - README and Docs/overview: Customer-facing deprecation announcement (new development → Swift CDA + SPM).
  - Added `DEPRECATION.md`: customer-facing deprecation notice (Swift SDK + SPM, existing CocoaPods users, support expectations, industry context).
 
+### Version: 3.16.1
+#### Date: Jul-13-2026
+
+##### Maintenance:
+ - Synced runtime SDK version (`X-User-Agent` header and bundle version) with the podspec release version
+
 ### Version: 3.16.0
 #### Date: Sep-22-2025
 

--- a/Contentstack.podspec
+++ b/Contentstack.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = 'Contentstack'
-s.version          = '3.16.0'
+s.version          = '3.16.1'
 s.summary          = 'Contentstack is a headless CMS with an API-first approach that puts content at the centre.'
 
 s.description      = <<-DESC
@@ -9,10 +9,10 @@ In a world where content is consumed via countless channels and form factors acr
 DESC
 
 s.homepage         = 'https://www.contentstack.com/'
-s.license          = { :type => 'Commercial',:text => 'See https://www.contentstack.com/'}
+s.license          = { :type => 'MIT',:file => 'LICENSE'}
 s.author           = { 'Contentstack' => 'support@contentstack.io' }
 
-s.source           = { :git => 'https://github.com/contentstack/contentstack-ios.git', :tag => 'v3.14.0' }
+s.source           = { :git => 'https://github.com/contentstack/contentstack-ios.git', :tag => 'v3.16.1' }
 s.social_media_url = 'https://twitter.com/Contentstack'
 
 s.ios.deployment_target = '12.0'

--- a/Contentstack/Info.plist
+++ b/Contentstack/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.1</string>
+	<string>3.16.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ContentstackInternal/CSIOCoreHTTPNetworking.m
+++ b/ContentstackInternal/CSIOCoreHTTPNetworking.m
@@ -15,7 +15,7 @@
 #import "NSObject+Extensions.h"
 #import "CSURLSessionManager.h"
 
-NSString *const sdkVersion = @"3.10.1";
+NSString *const sdkVersion = @"3.16.1";
 
 @interface CSIOCoreHTTPNetworking (){
     id networkChangeObserver;


### PR DESCRIPTION
Address a Snyk vulnerability by updating the SDK version to 3.16.1 and syncing related metadata. This ensures compliance and enhances security.